### PR TITLE
Fix README duplicate workspace link

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,6 @@ This workspace includes:
 
 [Learn more about this workspace setup and its capabilities](https://nx.dev/nx-api/js?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects) or run `npx nx graph` to visually explore what was created.
 
-[Learn more about this workspace setup and its capabilities](https://nx.dev/nx-api/js?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects) or run `npx nx graph` to visually explore what was created. Now, let's get you up to speed!
-
 ## Generate a library
 
 ```sh


### PR DESCRIPTION
## Summary
- remove redundant Nx workspace link in README

## Testing
- `pnpm nx run-many -t lint,test,build`
- `pnpm test:e2e` *(fails: E2E tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_684786e3b2b4832cb2838753ab966773