### PR TITLE
Update auth test suite name

### DIFF
--- a/packages/auth/vitest.config.ts
+++ b/packages/auth/vitest.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    name: '@packing-list/state-tests',
+    name: '@packing-list/auth-tests',
     include: ['src/**/*.test.ts'],
     environment: 'jsdom',
   },


### PR DESCRIPTION
## Summary
- fix auth test suite name

## Testing
- `pnpm nx run-many -t lint,test,build`
- `pnpm test:e2e` *(fails: Command failed with exit code 1)*

------
https://chatgpt.com/codex/tasks/task_e_684786d44778832c80fdd18f43484d9e