### PR TITLE
Fix Nx release link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ npx nx release
 
 Pass `--dry-run` to see what would happen without actually releasing the library.
 
-[Learn more about Nx release &raquo;](hhttps://nx.dev/features/manage-releases?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects)
+[Learn more about Nx release &raquo;](https://nx.dev/features/manage-releases?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects)
 
 ## Keep TypeScript project references up to date
 


### PR DESCRIPTION
## Summary
- fix broken Nx release link in README

## Testing
- `npx --yes nx run-many -t lint,test,build`
- `pnpm test:e2e` *(fails: E2E tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_684786c825ec832cbd3e0b5e0af9243f