### PR TITLE
Fix date formatting timezone bug

### DIFF
--- a/packages/shared-components/src/lib/Timeline.tsx
+++ b/packages/shared-components/src/lib/Timeline.tsx
@@ -24,7 +24,9 @@ const eventTypeIcons: Record<string, React.ReactElement> = {
 
 function formatDate(dateString: string): string {
   const date = new Date(dateString);
-  date.setTime(date.getTime() + date.getTimezoneOffset() * 60000);
+  // Adjust for timezone so that a date-only string displays the intended day
+  // regardless of the user's local timezone
+  date.setTime(date.getTime() - date.getTimezoneOffset() * 60000);
   return date.toLocaleDateString('en-US', {
     year: 'numeric',
     month: 'short',

--- a/packages/shared-components/src/lib/__tests__/Timeline.test.tsx
+++ b/packages/shared-components/src/lib/__tests__/Timeline.test.tsx
@@ -137,4 +137,23 @@ describe('Timeline', () => {
     expect(eventBox).not.toHaveClass('cursor-pointer');
     expect(eventBox).not.toHaveClass('hover:bg-base-200');
   });
+
+  it('should format dates consistently across timezones', () => {
+    const event: TripEvent = {
+      id: '1',
+      type: 'arrive_destination',
+      date: '2024-06-10',
+      location: 'Paris',
+    };
+
+    const spy = vi
+      .spyOn(Date.prototype, 'getTimezoneOffset')
+      .mockReturnValue(-240);
+
+    render(<Timeline events={[event]} />);
+
+    expect(screen.getByText('Jun 10, 2024')).toBeInTheDocument();
+
+    spy.mockRestore();
+  });
 });


### PR DESCRIPTION
## Summary
- fix timezone adjustment logic in `Timeline` component
- add test to ensure dates format correctly across timezones

## Testing
- `pnpm exec nx run-many -t lint,test,build`
- `pnpm test:e2e` *(fails: E2E tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_684784a84d40832c9ac2c04148cd9f87