### PR TITLE
Fix date tests with shared util

### DIFF
--- a/packages/frontend/components/RulePackDetails.tsx
+++ b/packages/frontend/components/RulePackDetails.tsx
@@ -6,6 +6,7 @@ import {
 } from '@packing-list/state';
 import { showToast } from './Toast';
 import { Info, Star, Users, Calendar, Tag } from 'lucide-react';
+import { formatDate } from '@packing-list/shared-utils';
 import * as Icons from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 
@@ -129,7 +130,7 @@ export function RulePackDetails({ pack }: RulePackDetailsProps) {
                 <span className="font-medium">Created</span>
               </div>
               <p data-testid="pack-created-date">
-                {new Date(pack.metadata.created).toLocaleDateString()}
+                {formatDate(pack.metadata.created)}
               </p>
             </div>
             <div>

--- a/packages/frontend/components/RulePackModal.tsx
+++ b/packages/frontend/components/RulePackModal.tsx
@@ -6,6 +6,7 @@ import {
   selectDefaultItemRules,
 } from '@packing-list/state';
 import { Modal } from '@packing-list/shared-components';
+import { formatDate } from '@packing-list/shared-utils';
 import { showToast } from './Toast';
 import { RulePackEditor } from './RulePackEditor';
 import { RulePackDetails } from './RulePackDetails';
@@ -362,11 +363,7 @@ export function RulePackModal() {
                       </div>
                       <div className="flex items-center gap-1">
                         <Calendar className="w-4 h-4" />
-                        <span>
-                          {new Date(
-                            pack.metadata.modified
-                          ).toLocaleDateString()}
-                        </span>
+                        <span>{formatDate(pack.metadata.modified)}</span>
                       </div>
                     </div>
 

--- a/packages/frontend/pages/days/TripWizard.tsx
+++ b/packages/frontend/pages/days/TripWizard.tsx
@@ -1,6 +1,7 @@
 import { useState, ChangeEvent, useEffect } from 'react';
 import { TripEvent } from '@packing-list/model';
 import { Timeline, Modal } from '@packing-list/shared-components';
+import { formatDate } from '@packing-list/shared-utils';
 import { uuid } from '../../utils/uuid';
 import { RulePackSelector } from '../../components/RulePackSelector';
 import { useAppDispatch, useAppSelector } from '@packing-list/state';
@@ -413,8 +414,7 @@ export function TripWizard({
                     <div>
                       <span className="font-medium">{dest.location}</span>
                       <span className="text-sm text-gray-500 ml-2">
-                        {new Date(dest.arriveDate).toLocaleDateString()} -{' '}
-                        {new Date(dest.leaveDate).toLocaleDateString()}
+                        {formatDate(dest.arriveDate)} - {formatDate(dest.leaveDate)}
                       </span>
                       {(dest.arriveNotes || dest.leaveNotes) && (
                         <div className="mt-2 text-sm">

--- a/packages/frontend/pages/trips/+Page.tsx
+++ b/packages/frontend/pages/trips/+Page.tsx
@@ -4,6 +4,7 @@ import {
   useAppDispatch,
   selectAccurateTripSummaries,
 } from '@packing-list/state';
+import { formatDate } from '@packing-list/shared-utils';
 import { Link } from '../../components/Link';
 import { PageHeader } from '../../components/PageHeader';
 import { PageContainer } from '../../components/PageContainer';
@@ -66,13 +67,6 @@ export default function TripsPage() {
     }
   };
 
-  const formatDate = (dateString: string) => {
-    return new Date(dateString).toLocaleDateString(undefined, {
-      year: 'numeric',
-      month: 'short',
-      day: 'numeric',
-    });
-  };
 
   const tripToDeleteData = tripSummaries.find((t) => t.tripId === tripToDelete);
 

--- a/packages/frontend/pages/trips/@tripId/+Page.tsx
+++ b/packages/frontend/pages/trips/@tripId/+Page.tsx
@@ -4,6 +4,7 @@ import { usePageContext } from 'vike-react/usePageContext';
 import { Link } from '../../../components/Link';
 import { PageHeader } from '../../../components/PageHeader';
 import { PageContainer } from '../../../components/PageContainer';
+import { formatDate } from '@packing-list/shared-utils';
 import { navigate } from 'vike/client/router';
 import {
   ArrowLeft,
@@ -49,13 +50,6 @@ export default function TripDetailsPage() {
     navigate('/');
   };
 
-  const formatDate = (dateString: string) => {
-    return new Date(dateString).toLocaleDateString(undefined, {
-      year: 'numeric',
-      month: 'long',
-      day: 'numeric',
-    });
-  };
 
   const getPackingProgress = () => {
     if (!trip || trip.totalItems === 0) {

--- a/packages/frontend/pages/trips/@tripId/settings/+Page.tsx
+++ b/packages/frontend/pages/trips/@tripId/settings/+Page.tsx
@@ -6,6 +6,7 @@ import { PageHeader } from '../../../../components/PageHeader';
 import { PageContainer } from '../../../../components/PageContainer';
 import { ConfirmDialog } from '@packing-list/shared-components';
 import { navigate } from 'vike/client/router';
+import { formatDate } from '@packing-list/shared-utils';
 import {
   ArrowLeft,
   Save,
@@ -348,11 +349,11 @@ export default function TripSettingsPage() {
 
             <div className="flex flex-col gap-2">
               <p className="text-sm text-base-content/70">
-                Created: {new Date(trip.createdAt).toLocaleDateString()}
+                Created: {formatDate(trip.createdAt)}
               </p>
               {trip.updatedAt !== trip.createdAt && (
                 <p className="text-sm text-base-content/70">
-                  Updated: {new Date(trip.updatedAt).toLocaleDateString()}
+                  Updated: {formatDate(trip.updatedAt)}
                 </p>
               )}
             </div>

--- a/packages/shared-components/package.json
+++ b/packages/shared-components/package.json
@@ -17,6 +17,7 @@
     "@packing-list/model": "workspace:*",
     "@packing-list/auth": "workspace:*",
     "@packing-list/auth-state": "workspace:*",
-    "@packing-list/state": "workspace:*"
+    "@packing-list/state": "workspace:*",
+    "@packing-list/shared-utils": "workspace:*"
   }
 }

--- a/packages/shared-components/src/lib/Timeline.tsx
+++ b/packages/shared-components/src/lib/Timeline.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { TripEvent } from '@packing-list/model';
 import { Home, MapPin, Luggage, CheckCircle } from 'lucide-react';
+import { formatDate } from '@packing-list/shared-utils';
 
 interface TimelineProps {
   events: TripEvent[];
@@ -22,15 +23,6 @@ const eventTypeIcons: Record<string, React.ReactElement> = {
   arrive_home: <CheckCircle className="w-4 h-4" />,
 };
 
-function formatDate(dateString: string): string {
-  const date = new Date(dateString);
-  date.setTime(date.getTime() + date.getTimezoneOffset() * 60000);
-  return date.toLocaleDateString('en-US', {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-  });
-}
 
 export function Timeline({
   events,

--- a/packages/shared-components/tsconfig.lib.json
+++ b/packages/shared-components/tsconfig.lib.json
@@ -7,11 +7,19 @@
     "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo",
     "emitDeclarationOnly": true,
     "forceConsistentCasingInFileNames": true,
-    "types": ["node"],
-    "lib": ["es2020", "dom"],
+    "types": [
+      "node"
+    ],
+    "lib": [
+      "es2020",
+      "dom"
+    ],
     "jsx": "react-jsx"
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx"
+  ],
   "references": [
     {
       "path": "../state/tsconfig.lib.json"
@@ -24,6 +32,9 @@
     },
     {
       "path": "../model/tsconfig.lib.json"
+    },
+    {
+      "path": "../shared-utils/tsconfig.lib.json"
     }
   ],
   "exclude": [

--- a/packages/shared-utils/src/index.ts
+++ b/packages/shared-utils/src/index.ts
@@ -1,2 +1,3 @@
 export * from './lib/calculate-rule.js';
 export * from './lib/calculate-rule-hash.js';
+export * from './lib/format-date.js';

--- a/packages/shared-utils/src/lib/__tests__/format-date.test.ts
+++ b/packages/shared-utils/src/lib/__tests__/format-date.test.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import { formatDate } from '../format-date.js';
+
+describe('formatDate', () => {
+  it('formats ISO dates consistently', () => {
+    expect(formatDate('2024-01-01')).toBe('Jan 1, 2024');
+    expect(formatDate('2024-12-31')).toBe('Dec 31, 2024');
+  });
+});

--- a/packages/shared-utils/src/lib/format-date.ts
+++ b/packages/shared-utils/src/lib/format-date.ts
@@ -1,0 +1,12 @@
+import { parseISO, format } from 'date-fns';
+
+/**
+ * Format an ISO date string in a timezone-agnostic way.
+ *
+ * @param iso ISO date string in `yyyy-MM-dd` format
+ * @param dateFormat Output format, defaults to `MMM d, yyyy`
+ */
+export function formatDate(iso: string, dateFormat = 'MMM d, yyyy'): string {
+  const date = parseISO(iso);
+  return format(date, dateFormat);
+}


### PR DESCRIPTION
## Summary
- add timezone-agnostic `formatDate` utility
- use `formatDate` across frontend and shared components
- add unit tests for `formatDate`

## Testing
- `npx nx run-many -t lint,test,build`
- `pnpm test:e2e` *(fails: E2E tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_68478a6ef77c832c9feabf69c8630fb7