### PR TITLE
refactor(sync): move storage to middleware

### DIFF
--- a/packages/frontend/components/SyncProvider.tsx
+++ b/packages/frontend/components/SyncProvider.tsx
@@ -134,11 +134,14 @@ export const SyncProvider: React.FC<SyncProviderProps> = ({ children }) => {
 
         // Pass Redux dispatch and current user ID to sync service options
         syncServiceRef.current = getSyncService({
-          dispatch: dispatchRef.current,
           reloadFromIndexedDB: handleReloadFromIndexedDB,
           userId: userId,
           demoMode: isDemoMode,
           callbacks: {
+            onTripUpsert: entityCallbacks.onTripUpsert,
+            onPersonUpsert: entityCallbacks.onPersonUpsert,
+            onItemUpsert: entityCallbacks.onItemUpsert,
+            onRulePackUpsert: entityCallbacks.onRulePackUpsert,
             onTripRuleUpsert: entityCallbacks.onTripRuleUpsert,
           },
         });
@@ -255,7 +258,6 @@ export const SyncProvider: React.FC<SyncProviderProps> = ({ children }) => {
 
       // Get the sync service and force sync
       const syncService = getSyncService({
-        dispatch: dispatchRef.current,
         demoMode: isDemoMode,
       });
       await syncService.forceSync();

--- a/packages/state/src/action-handlers/add-person.ts
+++ b/packages/state/src/action-handlers/add-person.ts
@@ -1,7 +1,6 @@
 import { Person } from '@packing-list/model';
 import { StoreType } from '../store.js';
 import { calculatePackingListHandler } from './calculate-packing-list.js';
-import { PersonStorage } from '@packing-list/offline-storage';
 
 export type AddPersonAction = {
   type: 'ADD_PERSON';
@@ -45,8 +44,6 @@ export const addPersonHandler = (
       },
     },
   };
-
-  PersonStorage.savePerson(action.payload).catch(console.error);
 
   // Recalculate packing list with new person
   return calculatePackingListHandler(stateWithNewPerson);

--- a/packages/state/src/action-handlers/calculate-packing-list.ts
+++ b/packages/state/src/action-handlers/calculate-packing-list.ts
@@ -4,8 +4,7 @@ import {
   Day,
   Person,
 } from '@packing-list/model';
-import type { RuleOverride, TripItem } from '@packing-list/model';
-import { ItemStorage } from '@packing-list/offline-storage';
+import type { RuleOverride } from '@packing-list/model';
 import { StoreType } from '../store.js';
 import {
   calculateRuleHash,
@@ -682,26 +681,6 @@ export const calculatePackingListHandler = (state: StoreType): StoreType => {
   // Preserve packed status and save to storage
   const existingItems = selectedTripData.calculated.packingListItems;
   const updatedItems = preservePackedStatus(packingListItems, existingItems);
-
-  // Save to storage
-  updatedItems.forEach((item) => {
-    const tripItem: TripItem = {
-      id: item.id,
-      tripId: selectedTripId,
-      name: item.name,
-      category: item.categoryId,
-      quantity: item.quantity,
-      packed: item.isPacked,
-      notes: item.notes,
-      personId: item.personId,
-      dayIndex: item.dayIndex,
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-      version: 1,
-      isDeleted: false,
-    };
-    ItemStorage.saveItem(tripItem).catch(console.error);
-  });
 
   // Update state
   return {

--- a/packages/state/src/action-handlers/create-item-rule.ts
+++ b/packages/state/src/action-handlers/create-item-rule.ts
@@ -2,10 +2,6 @@ import { DefaultItemRule } from '@packing-list/model';
 import { StoreType } from '../store.js';
 import { calculateDefaultItems } from './calculate-default-items.js';
 import { calculatePackingListHandler } from './calculate-packing-list.js';
-import {
-  DefaultItemRulesStorage,
-  TripRuleStorage,
-} from '@packing-list/offline-storage';
 import type { TripRule } from '@packing-list/model';
 
 export type CreateItemRuleAction = {
@@ -48,25 +44,6 @@ export const createItemRuleHandler = (
       },
     },
   };
-
-  // Save the rule definition to global storage for reuse across trips
-  DefaultItemRulesStorage.saveDefaultItemRule(action.payload).catch(
-    console.error
-  );
-
-  // Save the trip rule association
-  const now = new Date().toISOString();
-  const tripRule: TripRule = {
-    id: `${selectedTripId}-${action.payload.id}`,
-    tripId: selectedTripId,
-    ruleId: action.payload.id,
-    createdAt: now,
-    updatedAt: now,
-    version: 1,
-    isDeleted: false,
-  };
-
-  TripRuleStorage.saveTripRule(tripRule).catch(console.error);
 
   // Then recalculate default items
   const stateWithDefaultItems = calculateDefaultItems(stateWithNewRule);

--- a/packages/state/src/action-handlers/create-rule-pack.ts
+++ b/packages/state/src/action-handlers/create-rule-pack.ts
@@ -1,6 +1,5 @@
 import { RulePack } from '@packing-list/model';
 import { StoreType } from '../store.js';
-import { RulePacksStorage } from '@packing-list/offline-storage';
 
 export type CreateRulePackAction = {
   type: 'CREATE_RULE_PACK';
@@ -11,8 +10,6 @@ export const createRulePackHandler = (
   state: StoreType,
   action: CreateRulePackAction
 ): StoreType => {
-  RulePacksStorage.saveRulePack(action.payload).catch(console.error);
-
   return {
     ...state,
     rulePacks: [...state.rulePacks, action.payload],

--- a/packages/state/src/action-handlers/delete-item-rule.ts
+++ b/packages/state/src/action-handlers/delete-item-rule.ts
@@ -1,10 +1,6 @@
 import type { StoreType } from '../store.js';
 import { calculateDefaultItems } from './calculate-default-items.js';
 import { calculatePackingListHandler } from './calculate-packing-list.js';
-import {
-  DefaultItemRulesStorage,
-  TripRuleStorage,
-} from '@packing-list/offline-storage';
 
 export type DeleteItemRuleAction = {
   type: 'DELETE_ITEM_RULE';
@@ -51,14 +47,6 @@ export const deleteItemRuleHandler = (
 
   // Soft delete the rule from global storage
   // Note: We keep it in global storage as other trips might still use it
-  DefaultItemRulesStorage.deleteDefaultItemRule(action.payload.id).catch(
-    console.error
-  );
-
-  // Remove the trip rule association
-  TripRuleStorage.deleteTripRule(selectedTripId, action.payload.id).catch(
-    console.error
-  );
 
   // Then recalculate default items
   const stateWithDefaultItems = calculateDefaultItems(stateWithoutRule);

--- a/packages/state/src/action-handlers/delete-rule-pack.ts
+++ b/packages/state/src/action-handlers/delete-rule-pack.ts
@@ -1,5 +1,4 @@
 import { StoreType } from '../store.js';
-import { RulePacksStorage } from '@packing-list/offline-storage';
 
 export type DeleteRulePackAction = {
   type: 'DELETE_RULE_PACK';
@@ -17,8 +16,6 @@ export const deleteRulePackHandler = (
   if (!packToDelete) {
     return state; // Pack not found, nothing to delete
   }
-
-  RulePacksStorage.deleteRulePack(action.payload.id).catch(console.error);
 
   return {
     ...state,

--- a/packages/state/src/action-handlers/remove-person.ts
+++ b/packages/state/src/action-handlers/remove-person.ts
@@ -1,6 +1,5 @@
 import { StoreType } from '../store.js';
 import { calculatePackingListHandler } from './calculate-packing-list.js';
-import { PersonStorage } from '@packing-list/offline-storage';
 
 export type RemovePersonAction = {
   type: 'REMOVE_PERSON';
@@ -47,8 +46,6 @@ export const removePersonHandler = (
       },
     },
   };
-
-  PersonStorage.deletePerson(action.payload.id).catch(console.error);
 
   // Recalculate packing list without the removed person
   return calculatePackingListHandler(stateWithRemovedPerson);

--- a/packages/state/src/action-handlers/toggle-item-packed.ts
+++ b/packages/state/src/action-handlers/toggle-item-packed.ts
@@ -1,5 +1,4 @@
 import { StoreType } from '../store.js';
-import { ItemStorage } from '@packing-list/offline-storage';
 import type { TripItem } from '@packing-list/model';
 
 export type ToggleItemPackedAction = {
@@ -33,33 +32,8 @@ export const toggleItemPackedHandler = (
   const toggledItem = updatedItems.find((item) => item.id === itemId);
   if (toggledItem) {
     console.log(
-      `📦 [TOGGLE_ITEM_PACKED] Saving packed status: ${toggledItem.name} (${toggledItem.id}) -> ${toggledItem.isPacked}`
+      `📦 [TOGGLE_ITEM_PACKED] Toggled packed status: ${toggledItem.name} (${toggledItem.id}) -> ${toggledItem.isPacked}`
     );
-
-    // Convert PackingListItem to TripItem and save to IndexedDB
-    const tripItem: TripItem = {
-      id: toggledItem.id,
-      tripId: selectedTripId,
-      name: toggledItem.name,
-      category: toggledItem.categoryId,
-      quantity: toggledItem.quantity,
-      packed: toggledItem.isPacked,
-      notes: toggledItem.notes,
-      personId: toggledItem.personId,
-      dayIndex: toggledItem.dayIndex,
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-      version: 1,
-      isDeleted: false,
-    };
-
-    // Save to IndexedDB asynchronously
-    ItemStorage.saveItem(tripItem).catch((error) => {
-      console.error(
-        `❌ [TOGGLE_ITEM_PACKED] Failed to save item ${itemId}:`,
-        error
-      );
-    });
   }
 
   const updatedTripData = {

--- a/packages/state/src/action-handlers/toggle-rule-pack.ts
+++ b/packages/state/src/action-handlers/toggle-rule-pack.ts
@@ -9,10 +9,6 @@ import { calculateDefaultItems } from './calculate-default-items.js';
 import { calculatePackingListHandler } from './calculate-packing-list.js';
 import { ActionHandler } from '../actions.js';
 import { uuid } from '@packing-list/shared-utils';
-import {
-  DefaultItemRulesStorage,
-  TripRuleStorage,
-} from '@packing-list/offline-storage';
 
 export type ToggleRulePackAction = {
   type: 'TOGGLE_RULE_PACK';
@@ -71,9 +67,7 @@ export const toggleRulePackHandler: ActionHandler<ToggleRulePackAction> = (
           };
 
           // Save updated rule to storage
-          DefaultItemRulesStorage.saveDefaultItemRule(
-            defaultItemRules[existingRuleIndex]
-          ).catch(console.error);
+          // rule updated
         }
       } else {
         // Create new user instance of the rule
@@ -88,9 +82,7 @@ export const toggleRulePackHandler: ActionHandler<ToggleRulePackAction> = (
         newRuleIds.push(userRuleInstance.id);
 
         // Save new rule to storage
-        DefaultItemRulesStorage.saveDefaultItemRule(userRuleInstance).catch(
-          console.error
-        );
+        // rule created
       }
     }
 
@@ -106,7 +98,6 @@ export const toggleRulePackHandler: ActionHandler<ToggleRulePackAction> = (
         version: 1,
         isDeleted: false,
       };
-      TripRuleStorage.saveTripRule(tripRule).catch(console.error);
     }
 
     // Update the state with new rules
@@ -156,9 +147,7 @@ export const toggleRulePackHandler: ActionHandler<ToggleRulePackAction> = (
         result.push(updatedRule);
 
         // Save updated rule to storage
-        DefaultItemRulesStorage.saveDefaultItemRule(updatedRule).catch(
-          console.error
-        );
+        // updated rule after removing pack association
         return result;
       },
       [] as typeof selectedTripData.trip.defaultItemRules
@@ -166,9 +155,7 @@ export const toggleRulePackHandler: ActionHandler<ToggleRulePackAction> = (
 
     // Remove trip rule associations for removed rules
     for (const ruleId of removedRuleIds) {
-      TripRuleStorage.deleteTripRule(selectedTripId, ruleId).catch(
-        console.error
-      );
+      // trip rule association removed
     }
 
     // Update the state with modified rules

--- a/packages/state/src/action-handlers/trip-management.ts
+++ b/packages/state/src/action-handlers/trip-management.ts
@@ -1,5 +1,4 @@
 import { StoreType, TripData } from '../store.js';
-import { TripStorage } from '@packing-list/offline-storage';
 import { Trip, TripSummary } from '@packing-list/model';
 import { createEmptyTripData, initialState } from '../store.js';
 
@@ -106,19 +105,6 @@ export function createTripHandler(
   });
 
   // Persist trip asynchronously
-  TripStorage.saveTrip(tripModel)
-    .then(() => {
-      console.log(
-        '✅ [CREATE_TRIP] Trip saved successfully to IndexedDB:',
-        tripModel.id
-      );
-    })
-    .catch((error) => {
-      console.error(
-        '❌ [CREATE_TRIP] Failed to save trip to IndexedDB:',
-        error
-      );
-    });
 
   return {
     ...state,
@@ -177,11 +163,6 @@ export function deleteTripHandler(
       updatedSummaries.length > 0 ? updatedSummaries[0].tripId : null;
   }
 
-  // Persist deletion asynchronously
-  if (existingTrip) {
-    TripStorage.deleteTrip(tripId).catch(console.error);
-  }
-
   return {
     ...state,
     trips: {
@@ -209,18 +190,6 @@ export function updateTripSummaryHandler(
         }
       : summary
   );
-
-  // Persist update asynchronously
-  const tripData = state.trips.byId[tripId];
-  if (tripData) {
-    const updatedTrip: Trip = {
-      ...(tripData.trip as Trip),
-      title,
-      description: description || '',
-      updatedAt: new Date().toISOString(),
-    };
-    TripStorage.saveTrip(updatedTrip).catch(console.error);
-  }
 
   return {
     ...state,

--- a/packages/state/src/action-handlers/update-item-rule.ts
+++ b/packages/state/src/action-handlers/update-item-rule.ts
@@ -2,7 +2,6 @@ import type { DefaultItemRule } from '@packing-list/model';
 import type { StoreType } from '../store.js';
 import { calculateDefaultItems } from './calculate-default-items.js';
 import { calculatePackingListHandler } from './calculate-packing-list.js';
-import { DefaultItemRulesStorage } from '@packing-list/offline-storage';
 
 export type UpdateItemRuleAction = {
   type: 'UPDATE_ITEM_RULE';
@@ -45,10 +44,6 @@ export const updateItemRuleHandler = (
       },
     },
   };
-
-  DefaultItemRulesStorage.saveDefaultItemRule(action.payload).catch(
-    console.error
-  );
 
   // Then recalculate default items
   const stateWithDefaultItems = calculateDefaultItems(stateWithUpdatedRule);

--- a/packages/state/src/action-handlers/update-person.ts
+++ b/packages/state/src/action-handlers/update-person.ts
@@ -1,7 +1,6 @@
 import { Person } from '@packing-list/model';
 import { StoreType } from '../store.js';
 import { calculatePackingListHandler } from './calculate-packing-list.js';
-import { PersonStorage } from '@packing-list/offline-storage';
 
 export type UpdatePersonAction = {
   type: 'UPDATE_PERSON';
@@ -41,8 +40,6 @@ export const updatePersonHandler = (
       },
     },
   };
-
-  PersonStorage.savePerson(action.payload).catch(console.error);
 
   // Recalculate packing list with updated person
   return calculatePackingListHandler(stateWithUpdatedPerson);

--- a/packages/state/src/action-handlers/update-rule-pack.ts
+++ b/packages/state/src/action-handlers/update-rule-pack.ts
@@ -1,6 +1,5 @@
 import { RulePack } from '@packing-list/model';
 import { StoreType } from '../store.js';
-import { RulePacksStorage } from '@packing-list/offline-storage';
 
 export type UpdateRulePackAction = {
   type: 'UPDATE_RULE_PACK';
@@ -11,8 +10,6 @@ export const updateRulePackHandler = (
   state: StoreType,
   action: UpdateRulePackAction
 ): StoreType => {
-  RulePacksStorage.saveRulePack(action.payload).catch(console.error);
-
   return {
     ...state,
     rulePacks: state.rulePacks.map((pack) =>

--- a/packages/state/src/action-handlers/update-trip-events.ts
+++ b/packages/state/src/action-handlers/update-trip-events.ts
@@ -1,6 +1,5 @@
 import { TripEvent } from '@packing-list/model';
 import { StoreType } from '../store.js';
-import { TripStorage } from '@packing-list/offline-storage';
 import { enumerateTripDays } from './calculate-days.js';
 import { calculatePackingListHandler } from './calculate-packing-list.js';
 
@@ -47,10 +46,6 @@ export const updateTripEventsHandler = (
       },
     },
   };
-
-  // Save to storage - create a minimal trip model for storage
-
-  TripStorage.saveTrip(updatedTrip).catch(console.error);
 
   // Recalculate packing list with the new days
   return calculatePackingListHandler(updatedState);

--- a/packages/state/src/lib/sync/sync-integration.ts
+++ b/packages/state/src/lib/sync/sync-integration.ts
@@ -119,6 +119,18 @@ export const createEntityCallbacks = (
   dispatch: (action: AllActions) => void
 ) => {
   return {
+    onTripUpsert: (trip: Trip) => {
+      dispatch({ type: 'UPSERT_SYNCED_TRIP', payload: trip });
+    },
+    onPersonUpsert: (person: Person) => {
+      dispatch({ type: 'UPSERT_SYNCED_PERSON', payload: person });
+    },
+    onItemUpsert: (item: TripItem) => {
+      dispatch({ type: 'UPSERT_SYNCED_ITEM', payload: item });
+    },
+    onRulePackUpsert: (pack: RulePack) => {
+      dispatch({ type: 'UPSERT_SYNCED_RULE_PACK', payload: pack });
+    },
     onTripRuleUpsert: (tripRule: TripRule) => {
       console.log(
         `🔗 [SYNC INTEGRATION] Associating rule ${tripRule.ruleId} with trip ${tripRule.tripId}`


### PR DESCRIPTION
## Summary
- delegate IndexedDB saves to sync middleware
- dispatch upsert callbacks via middleware rather than service
- cleanup SyncProvider integration

## Testing
- `pnpm nx run-many -t lint,test,build`
- `pnpm test:e2e` *(fails: Docker daemon missing)*

------
https://chatgpt.com/codex/tasks/task_e_685228910b80832cac522d771ddd1a65