### PR TITLE
fix: misc fixes from post-launch smoke tests

### DIFF
--- a/packages/frontend/pages/people/+Page.tsx
+++ b/packages/frontend/pages/people/+Page.tsx
@@ -11,6 +11,7 @@ import { NoTripSelected } from '../../components/NoTripSelected';
 import { FlowContinueButton } from '../../components/FlowContinueButton';
 // import { Link } from '../../components/Link';
 import { Settings } from 'lucide-react';
+import { Link } from '@packing-list/shared-components';
 
 export default function PeoplePage() {
   const selectedTripId = useAppSelector(selectSelectedTripId);
@@ -36,14 +37,14 @@ export default function PeoplePage() {
       <PageHeader
         title="People on this Trip"
         actions={
-          <a
+          <Link
             href="/people/manage"
             className="btn btn-outline btn-sm ml-auto"
             title="Manage Templates"
           >
             <Settings className="w-4 h-4" />
             Manage Templates
-          </a>
+          </Link>
         }
       />
       <HelpBlurb storageKey="travelers" title="Managing Travelers">

--- a/packages/frontend/pages/people/components/PersonCard.tsx
+++ b/packages/frontend/pages/people/components/PersonCard.tsx
@@ -6,7 +6,14 @@ import {
 } from '@packing-list/model';
 import { useState } from 'react';
 import { PersonForm } from './PersonForm';
-import { UserCheck, User, MoreVertical, Bookmark } from 'lucide-react';
+import {
+  UserCheck,
+  User,
+  MoreVertical,
+  Bookmark,
+  Pencil,
+  Trash,
+} from 'lucide-react';
 import {
   useAppSelector,
   selectUserProfile,
@@ -127,6 +134,7 @@ export const PersonCard = ({ person, onDelete }: PersonCardProps) => {
                     }}
                     data-testid="edit-person-button"
                   >
+                    <Pencil className="h-3 w-3" />
                     Edit
                   </button>
                 )}
@@ -151,6 +159,7 @@ export const PersonCard = ({ person, onDelete }: PersonCardProps) => {
                     }}
                     data-testid="delete-person-button"
                   >
+                    <Trash className="h-3 w-3" />
                     Delete
                   </button>
                 )}

--- a/packages/state/src/lib/sync/actions.ts
+++ b/packages/state/src/lib/sync/actions.ts
@@ -383,7 +383,7 @@ export const pullAllDataFromServer = createAsyncThunk(
         .from('user_profiles')
         .select('preferences, updated_at')
         .eq('id', params.userId)
-        .single();
+        .maybeSingle();
 
     if (userPreferencesError && userPreferencesError.code !== 'PGRST116') {
       console.error(


### PR DESCRIPTION
This pull request makes improvements to the frontend components and state management. The most important changes include replacing HTML anchor tags with the `Link` component, adding new icons to the `PersonCard` component, and modifying the Supabase query method for user profiles.

### Frontend component updates:

* [`packages/frontend/pages/people/+Page.tsx`](diffhunk://#diff-fa6a2846b23868f450431ee79f81b4255ea570c20e7f127190e9cd032398e600R14): Replaced the `<a>` tag with the `Link` component from `@packing-list/shared-components` for better consistency and reusability. [[1]](diffhunk://#diff-fa6a2846b23868f450431ee79f81b4255ea570c20e7f127190e9cd032398e600R14) [[2]](diffhunk://#diff-fa6a2846b23868f450431ee79f81b4255ea570c20e7f127190e9cd032398e600L39-R47)
* [`packages/frontend/pages/people/components/PersonCard.tsx`](diffhunk://#diff-9e255358da5860d50eb6dec4daafcc4eedc261559806e7a84de403ee2562ab7bL9-R16): Added `Pencil` and `Trash` icons from `lucide-react` to the "Edit" and "Delete" buttons in the `PersonCard` component for improved visual cues. [[1]](diffhunk://#diff-9e255358da5860d50eb6dec4daafcc4eedc261559806e7a84de403ee2562ab7bL9-R16) [[2]](diffhunk://#diff-9e255358da5860d50eb6dec4daafcc4eedc261559806e7a84de403ee2562ab7bR137) [[3]](diffhunk://#diff-9e255358da5860d50eb6dec4daafcc4eedc261559806e7a84de403ee2562ab7bR162)

### State management update:

* [`packages/state/src/lib/sync/actions.ts`](diffhunk://#diff-a016fa656b4fc684a27ad589f1b408f3a6d3a2397ee41ffee66947c6a927dad9L386-R386): Changed the Supabase query method from `.single()` to `.maybeSingle()` in the `pullAllDataFromServer` function to handle cases where no matching record is found without throwing an error.