### PR TITLE
test(shared-components): add component unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
     "@types/jest": "^29.5.14",
+    "@types/jsdom": "^21.1.7",
     "@types/node": "18.16.9",
     "@types/react": "^19.1.6",
     "@types/react-dom": "^19.1.6",

--- a/packages/shared-components/src/Banner.test.tsx
+++ b/packages/shared-components/src/Banner.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { BannerProvider, Banner, useBannerHeight } from './Banner.js';
+
+// Helper component to expose total banner height
+const HeightDisplay = () => {
+  const height = useBannerHeight();
+  return <div data-testid="total-height">{height}</div>;
+};
+
+describe('BannerProvider and Banner', () => {
+  it('registers banners and calculates offsets', async () => {
+    // Force offsetHeight for jsdom
+    Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+      configurable: true,
+      value: 20,
+    });
+
+    render(
+      <BannerProvider>
+        <Banner id="one" priority={10} visible className="banner-one">
+          Banner 1
+        </Banner>
+        <Banner id="two" priority={20} visible className="banner-two">
+          Banner 2
+        </Banner>
+        <HeightDisplay />
+      </BannerProvider>
+    );
+
+    const banner1 = screen.getByText('Banner 1').closest('.banner-one') as HTMLElement;
+    const banner2 = screen.getByText('Banner 2').closest('.banner-two') as HTMLElement;
+
+    await waitFor(() => {
+      expect(banner1.getAttribute('style')).toContain('bottom: 0px');
+      expect(banner2.getAttribute('style')).toContain('bottom: 20px');
+      expect(screen.getByTestId('total-height')).toHaveTextContent('40');
+    });
+  });
+});

--- a/packages/shared-components/src/ConflictBanner.test.tsx
+++ b/packages/shared-components/src/ConflictBanner.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { ConflictBanner } from './ConflictBanner.js';
+import { BannerProvider } from './Banner.js';
+import type { SyncConflict } from '@packing-list/model';
+
+vi.mock('lucide-react', () => ({
+  AlertTriangle: ({ className }: { className?: string }) => (
+    <div data-testid="alert" className={className} />
+  ),
+  Eye: ({ className }: { className?: string }) => (
+    <div data-testid="eye" className={className} />
+  ),
+  X: ({ className }: { className?: string }) => (
+    <div data-testid="x" className={className} />
+  ),
+}));
+
+const conflict: SyncConflict = {
+  id: 'c',
+  entityType: 'trip',
+  entityId: 't',
+  localVersion: {},
+  serverVersion: {},
+  conflictType: 'update_conflict',
+  timestamp: 0,
+};
+
+describe('ConflictBanner', () => {
+  it('renders and handles actions', () => {
+    const onView = vi.fn();
+    const onDismiss = vi.fn();
+
+    render(
+      <BannerProvider>
+        <ConflictBanner
+          conflicts={[conflict]}
+          onViewConflicts={onView}
+          onDismiss={onDismiss}
+        />
+      </BannerProvider>
+    );
+
+    expect(
+      screen.getByText('1 sync conflict needs attention')
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Resolve'));
+    expect(onView).toHaveBeenCalled();
+
+    fireEvent.click(screen.getByLabelText('Dismiss'));
+    expect(onDismiss).toHaveBeenCalled();
+  });
+
+  it('does not render when no conflicts', () => {
+    render(
+      <BannerProvider>
+        <ConflictBanner conflicts={[]} onViewConflicts={() => undefined} />
+      </BannerProvider>
+    );
+    expect(screen.queryByText(/sync conflict/)).toBeNull();
+  });
+});

--- a/packages/shared-components/src/ConflictDiffView.test.tsx
+++ b/packages/shared-components/src/ConflictDiffView.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { ConflictDiffView } from './ConflictDiffView.js';
+
+vi.mock('lucide-react', () => ({
+  ChevronDown: ({ className }: { className?: string }) => (
+    <div data-testid="chevron-down" className={className} />
+  ),
+  ChevronRight: ({ className }: { className?: string }) => (
+    <div data-testid="chevron-right" className={className} />
+  ),
+  Plus: ({ className }: { className?: string }) => (
+    <div data-testid="plus" className={className} />
+  ),
+  Minus: ({ className }: { className?: string }) => (
+    <div data-testid="minus" className={className} />
+  ),
+  Edit3: ({ className }: { className?: string }) => (
+    <div data-testid="edit3" className={className} />
+  ),
+}));
+
+describe('ConflictDiffView', () => {
+  it('renders diff information', () => {
+    render(
+      <ConflictDiffView
+        localData={{ title: 'A', count: 1 }}
+        serverData={{ title: 'B', count: 1, extra: true }}
+      />
+    );
+
+    expect(screen.getByText('2 fields changed')).toBeInTheDocument();
+    expect(screen.getByText('title')).toBeInTheDocument();
+    expect(screen.getByText('extra')).toBeInTheDocument();
+    expect(screen.getByText('Show 1 unchanged fields')).toBeInTheDocument();
+  });
+});

--- a/packages/shared-components/src/ConflictList.test.tsx
+++ b/packages/shared-components/src/ConflictList.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { ConflictList } from './ConflictList.js';
+import type { SyncConflict } from '@packing-list/model';
+
+vi.mock('lucide-react', () => ({
+  AlertTriangle: ({ className }: { className?: string }) => (
+    <div data-testid="alert" className={className} />
+  ),
+  Clock: ({ className }: { className?: string }) => (
+    <div data-testid="clock" className={className} />
+  ),
+  ChevronRight: ({ className }: { className?: string }) => (
+    <div data-testid="chevron" className={className} />
+  ),
+}));
+
+const makeConflict = (id: string): SyncConflict => ({
+  id,
+  entityType: 'trip',
+  entityId: 't',
+  localVersion: { name: 'Local' },
+  serverVersion: { name: 'Server' },
+  conflictType: 'update_conflict',
+  timestamp: Date.now(),
+});
+
+describe('ConflictList', () => {
+  it('shows empty state', () => {
+    render(<ConflictList conflicts={[]} onResolveConflict={() => undefined} />);
+    expect(screen.getByText('No sync conflicts')).toBeInTheDocument();
+  });
+
+  it('calls onResolveConflict when item clicked', () => {
+    const conflict = makeConflict('1');
+    const onResolve = vi.fn();
+    render(
+      <ConflictList conflicts={[conflict]} onResolveConflict={onResolve} />
+    );
+    const element = screen.getByText('Trip Conflict').parentElement?.parentElement;
+    if (element) {
+      fireEvent.click(element);
+    }
+    expect(onResolve).toHaveBeenCalledWith(conflict);
+  });
+
+  it('handles bulk resolve actions', () => {
+    const conflicts = [makeConflict('1'), makeConflict('2')];
+    const onResolveAll = vi.fn();
+    render(
+      <ConflictList
+        conflicts={conflicts}
+        onResolveConflict={() => undefined}
+        onResolveAll={onResolveAll}
+      />
+    );
+
+    fireEvent.click(screen.getByText('Use Server (All)'));
+    expect(onResolveAll).toHaveBeenCalledWith('server');
+    fireEvent.click(screen.getByText('Keep Local (All)'));
+    expect(onResolveAll).toHaveBeenCalledWith('local');
+  });
+});

--- a/packages/shared-components/src/Dialog.test.tsx
+++ b/packages/shared-components/src/Dialog.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { Modal, ConfirmDialog } from './Dialog.js';
+
+// Mock icons used in the modal
+vi.mock('lucide-react', () => ({
+  X: ({ className }: { className?: string }) => (
+    <div data-testid="icon-x" className={className} />
+  ),
+}));
+
+describe('Modal component', () => {
+  it('renders children when open', () => {
+    render(
+      <Modal isOpen onClose={() => undefined} title="Test Modal">
+        <span>Content</span>
+      </Modal>
+    );
+    expect(screen.getByText('Content')).toBeInTheDocument();
+    expect(screen.getByText('Test Modal')).toBeInTheDocument();
+  });
+
+  it('calls onClose when close button clicked', () => {
+    const onClose = vi.fn();
+    render(<Modal isOpen onClose={onClose} title="Close Test"><div>Test content</div></Modal>);
+    fireEvent.click(screen.getByLabelText('Close modal'));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('closes on escape key', () => {
+    const onClose = vi.fn();
+    render(<Modal isOpen onClose={onClose}><div>Test content</div></Modal>);
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('closes on backdrop click', () => {
+    const onClose = vi.fn();
+    render(<Modal isOpen onClose={onClose}><div>Test content</div></Modal>);
+    const backdrop = screen.getByRole('button', { name: 'close' });
+    fireEvent.click(backdrop);
+    expect(onClose).toHaveBeenCalled();
+  });
+});
+
+describe('ConfirmDialog component', () => {
+  it('handles confirm and cancel actions', () => {
+    const onConfirm = vi.fn();
+    const onClose = vi.fn();
+    const onCancel = vi.fn();
+
+    render(
+      <ConfirmDialog
+        isOpen
+        onClose={onClose}
+        message="Are you sure?"
+        onConfirm={onConfirm}
+        onCancel={onCancel}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('confirm-dialog-cancel-button'));
+    expect(onCancel).toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
+
+    fireEvent.click(screen.getByTestId('confirm-continue-button'));
+    expect(onConfirm).toHaveBeenCalled();
+  });
+});

--- a/packages/shared-components/src/NestedObjectDiff.test.tsx
+++ b/packages/shared-components/src/NestedObjectDiff.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { NestedObjectDiff } from './NestedObjectDiff.js';
+
+vi.mock('lucide-react', () => ({
+  ChevronDown: ({ className }: { className?: string }) => (
+    <div data-testid="chevron-down" className={className} />
+  ),
+  ChevronRight: ({ className }: { className?: string }) => (
+    <div data-testid="chevron-right" className={className} />
+  ),
+  Plus: ({ className }: { className?: string }) => (
+    <div data-testid="plus" className={className} />
+  ),
+  Minus: ({ className }: { className?: string }) => (
+    <div data-testid="minus" className={className} />
+  ),
+  Edit3: ({ className }: { className?: string }) => (
+    <div data-testid="edit3" className={className} />
+  ),
+}));
+
+describe('NestedObjectDiff', () => {
+  it('shows primitive differences', () => {
+    render(<NestedObjectDiff localValue="a" serverValue="b" />);
+    expect(screen.getByText('Local')).toBeInTheDocument();
+    expect(screen.getByText('"a"')).toBeInTheDocument();
+    expect(screen.getByText('"b"')).toBeInTheDocument();
+  });
+
+  it('handles nested object expansion', () => {
+    render(
+      <NestedObjectDiff
+        localValue={{ a: { b: 1 } }}
+        serverValue={{ a: { b: 2 } }}
+        expanded={false}
+      />
+    );
+    fireEvent.click(screen.getByText('Expand details'));
+    expect(screen.getByText('Object Differences')).toBeInTheDocument();
+    expect(screen.getByText('b:')).toBeInTheDocument();
+  });
+});

--- a/packages/shared-components/src/OfflineBanner.test.tsx
+++ b/packages/shared-components/src/OfflineBanner.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { OfflineBanner } from './OfflineBanner.js';
+import { BannerProvider } from './Banner.js';
+
+vi.mock('lucide-react', () => ({
+  WifiOff: ({ className }: { className?: string }) => (
+    <div data-testid="wifi-off" className={className} />
+  ),
+}));
+
+describe('OfflineBanner', () => {
+  it('renders when offline', () => {
+    render(
+      <BannerProvider>
+        <OfflineBanner isOffline={true} />
+      </BannerProvider>
+    );
+    expect(
+      screen.getByText(
+        'You appear to be offline. Some features may not work properly.'
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('does not render when online', () => {
+    render(
+      <BannerProvider>
+        <OfflineBanner isOffline={false} />
+      </BannerProvider>
+    );
+    expect(
+      screen.queryByText(
+        'You appear to be offline. Some features may not work properly.'
+      )
+    ).toBeNull();
+  });
+});

--- a/packages/shared-components/src/SyncStatusIndicator.test.tsx
+++ b/packages/shared-components/src/SyncStatusIndicator.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { SyncStatusBadge } from './SyncStatusIndicator.js';
+import type { SyncState } from '@packing-list/model';
+
+vi.mock('lucide-react', () => ({
+  Wifi: ({ className }: { className?: string }) => (
+    <div data-testid="wifi" className={className} />
+  ),
+  WifiOff: ({ className }: { className?: string }) => (
+    <div data-testid="wifi-off" className={className} />
+  ),
+  RotateCw: ({ className }: { className?: string }) => (
+    <div data-testid="rotate" className={className} />
+  ),
+  AlertTriangle: ({ className }: { className?: string }) => (
+    <div data-testid="alert" className={className} />
+  ),
+  CheckCircle: ({ className }: { className?: string }) => (
+    <div data-testid="check" className={className} />
+  ),
+  Clock: ({ className }: { className?: string }) => (
+    <div data-testid="clock" className={className} />
+  ),
+}));
+
+const baseState: SyncState = {
+  lastSyncTimestamp: null,
+  isOnline: true,
+  isSyncing: false,
+  pendingChanges: [],
+  conflicts: [],
+};
+
+describe('SyncStatusBadge', () => {
+  it('shows offline status', () => {
+    const state = { ...baseState, isOnline: false };
+    render(<SyncStatusBadge syncState={state} />);
+    expect(screen.getByTestId('sync-offline-badge')).toBeInTheDocument();
+    expect(screen.getByText('Offline')).toBeInTheDocument();
+  });
+
+  it('shows syncing status', () => {
+    const state = { ...baseState, isSyncing: true };
+    render(<SyncStatusBadge syncState={state} />);
+    expect(screen.getByTestId('sync-syncing-badge')).toBeInTheDocument();
+    expect(screen.getByText('Syncing...')).toBeInTheDocument();
+  });
+
+  it('shows pending changes', () => {
+    const state = {
+      ...baseState,
+      pendingChanges: [
+        {
+          id: '1',
+          operation: 'update',
+          timestamp: 0,
+          userId: 'u',
+          version: 1,
+          synced: false,
+          entityType: 'trip',
+          entityId: 't',
+          data: { id: 't' },
+        },
+      ],
+    } as unknown as SyncState;
+    render(<SyncStatusBadge syncState={state} />);
+    expect(screen.getByTestId('sync-pending-badge')).toBeInTheDocument();
+    expect(screen.getByText('1 pending')).toBeInTheDocument();
+  });
+
+  it('shows conflict status', () => {
+    const state = {
+      ...baseState,
+      conflicts: [
+        {
+          id: 'c',
+          entityType: 'trip',
+          entityId: 't',
+          localVersion: {},
+          serverVersion: {},
+          conflictType: 'update_conflict' as const,
+          timestamp: 0,
+        },
+      ],
+    };
+    render(<SyncStatusBadge syncState={state} />);
+    expect(screen.getByTestId('sync-conflict-badge')).toBeInTheDocument();
+    expect(screen.getByText('1 conflict')).toBeInTheDocument();
+  });
+
+  it('shows synced status when no issues', () => {
+    render(<SyncStatusBadge syncState={baseState} />);
+    expect(screen.getByTestId('sync-synced-badge')).toBeInTheDocument();
+    expect(screen.getByText('Synced')).toBeInTheDocument();
+  });
+});

--- a/packages/shared-utils/src/lib/calculate-rule-hash.test.ts
+++ b/packages/shared-utils/src/lib/calculate-rule-hash.test.ts
@@ -8,7 +8,7 @@ describe('calculateRuleHash', () => {
     originalRuleId: '1',
     name: 'Test',
     calculation: { baseQuantity: 1 },
-    conditions: [{ property: 'test', operator: 'equals', value: 'value' }],
+    conditions: [{ type: 'person', field: 'age', operator: '==', value: 25 }],
   };
 
   it('produces stable hashes for identical rules', () => {

--- a/packages/shared-utils/src/lib/calculate-rule-hash.test.ts
+++ b/packages/shared-utils/src/lib/calculate-rule-hash.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { calculateRuleHash } from './calculate-rule-hash.js';
+import type { DefaultItemRule } from '@packing-list/model';
+
+describe('calculateRuleHash', () => {
+  const baseRule: DefaultItemRule = {
+    id: '1',
+    originalRuleId: '1',
+    name: 'Test',
+    calculation: { baseQuantity: 1 },
+    conditions: [{ property: 'test', operator: 'equals', value: 'value' }],
+  };
+
+  it('produces stable hashes for identical rules', () => {
+    const hash1 = calculateRuleHash(baseRule);
+    const hash2 = calculateRuleHash({ ...baseRule });
+    expect(hash1).toBe(hash2);
+  });
+
+  it('produces different hashes for different rules', () => {
+    const otherRule: DefaultItemRule = {
+      ...baseRule,
+      name: 'Other',
+    };
+    const hash1 = calculateRuleHash(baseRule);
+    const hash2 = calculateRuleHash(otherRule);
+    expect(hash1).not.toBe(hash2);
+  });
+});

--- a/packages/shared-utils/src/lib/calculate-rule.test.ts
+++ b/packages/shared-utils/src/lib/calculate-rule.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'vitest';
+import {
+  calculateItemQuantity,
+  calculateNumDaysMeetingCondition,
+  calculateNumPeopleMeetingCondition,
+  calculateRuleTotal,
+  compare,
+} from './calculate-rule.js';
+import type { DefaultItemRule, Person, Day } from '@packing-list/model';
+
+describe('calculate-rule utilities', () => {
+  it('compare handles numeric and array operators', () => {
+    expect(compare(3, '>', 2)).toBe(true);
+    expect(compare(3, '<', 2)).toBe(false);
+    expect(compare(['a', 'b'], 'in', 'a')).toBe(true);
+    expect(compare('a', 'in', ['a', 'b'])).toBe(true);
+  });
+
+  it('calculates item quantity with per person and per day flags', () => {
+    const qty = calculateItemQuantity(
+      1,
+      true,
+      true,
+      { every: 2, roundUp: true },
+      3,
+      5
+    );
+    // perPerson multiplies by people (3) and perDay multiplies by daysPattern result ceil(5/2)=3
+    expect(qty).toBe(9);
+  });
+
+  it('counts people and days meeting conditions', () => {
+    const people: Person[] = [
+      {
+        id: '1',
+        tripId: 't',
+        name: 'Alice',
+        createdAt: '',
+        updatedAt: '',
+        version: 1,
+        isDeleted: false,
+        age: 20,
+      },
+      {
+        id: '2',
+        tripId: 't',
+        name: 'Bob',
+        createdAt: '',
+        updatedAt: '',
+        version: 1,
+        isDeleted: false,
+        age: 30,
+      },
+    ];
+    const days: Day[] = [
+      {
+        location: 'a',
+        expectedClimate: 'hot',
+        items: [],
+        travel: false,
+        date: 1,
+      },
+      {
+        location: 'b',
+        expectedClimate: 'cold',
+        items: [],
+        travel: false,
+        date: 2,
+      },
+    ];
+    const peopleCount = calculateNumPeopleMeetingCondition(people, [
+      { type: 'person', field: 'age', operator: '>', value: 25 },
+    ]);
+    const daysCount = calculateNumDaysMeetingCondition(days, [
+      { type: 'day', field: 'expectedClimate', operator: '==', value: 'hot' },
+    ]);
+    expect(peopleCount).toBe(1);
+    expect(daysCount).toBe(1);
+  });
+
+  it('calculates rule total with extra items and conditions', () => {
+    const rule: DefaultItemRule = {
+      id: 'r1',
+      originalRuleId: 'r1',
+      name: 'Socks',
+      calculation: {
+        baseQuantity: 1,
+        perPerson: true,
+        perDay: true,
+        daysPattern: { every: 1, roundUp: true },
+        extraItems: { quantity: 2, perPerson: false, perDay: false },
+      },
+      conditions: [
+        { type: 'person', field: 'age', operator: '>=', value: 18 },
+        {
+          type: 'day',
+          field: 'expectedClimate',
+          operator: '==',
+          value: 'cold',
+        },
+      ],
+    };
+    const people: Person[] = [
+      {
+        id: '1',
+        tripId: 't',
+        name: 'Alice',
+        age: 20,
+        createdAt: '',
+        updatedAt: '',
+        version: 1,
+        isDeleted: false,
+      },
+      {
+        id: '2',
+        tripId: 't',
+        name: 'Bob',
+        age: 16,
+        createdAt: '',
+        updatedAt: '',
+        version: 1,
+        isDeleted: false,
+      },
+    ];
+    const days: Day[] = [
+      {
+        location: 'a',
+        expectedClimate: 'cold',
+        items: [],
+        travel: false,
+        date: 1,
+      },
+      {
+        location: 'b',
+        expectedClimate: 'warm',
+        items: [],
+        travel: false,
+        date: 2,
+      },
+    ];
+
+    const total = calculateRuleTotal(rule, people, days);
+    // Only Alice and first day meet conditions => people=1 days=1
+    // baseQuantity 1 * 1 * 1 =1 ; extra items 2
+    expect(total).toBe(3);
+  });
+});

--- a/packages/shared-utils/src/lib/deep-equal.test.ts
+++ b/packages/shared-utils/src/lib/deep-equal.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { deepEqual } from './deep-equal.js';
+
+describe('deepEqual', () => {
+  it('handles objects with keys in different order', () => {
+    const a = { foo: 1, bar: { baz: [1, 2, 3] } };
+    const b = { bar: { baz: [1, 2, 3] }, foo: 1 };
+    expect(deepEqual(a, b)).toBe(true);
+  });
+
+  it('detects unequal primitive values', () => {
+    expect(deepEqual(1, 2)).toBe(false);
+  });
+
+  it('detects unequal nested objects', () => {
+    const a = { foo: { bar: 1 } };
+    const b = { foo: { bar: 2 } };
+    expect(deepEqual(a, b)).toBe(false);
+  });
+
+  it('compares arrays by value', () => {
+    expect(deepEqual([1, 2, 3], [1, 2, 3])).toBe(true);
+    expect(deepEqual([1, 2], [2, 1])).toBe(false);
+  });
+
+  it('handles null and undefined values', () => {
+    expect(deepEqual(null, null)).toBe(true);
+    expect(deepEqual(undefined, undefined)).toBe(true);
+    expect(deepEqual(null, undefined)).toBe(false);
+    expect(deepEqual(null, {})).toBe(false);
+  });
+
+  it('handles equal primitive values', () => {
+    expect(deepEqual(1, 1)).toBe(true);
+    expect(deepEqual('hello', 'hello')).toBe(true);
+    expect(deepEqual(true, true)).toBe(true);
+  });
+
+  it('handles empty collections', () => {
+    expect(deepEqual({}, {})).toBe(true);
+    expect(deepEqual([], [])).toBe(true);
+    expect(deepEqual({}, [])).toBe(false);
+  });
+
+  it('handles mixed type comparisons', () => {
+    expect(deepEqual({}, [])).toBe(false);
+    expect(deepEqual([], {})).toBe(false);
+    expect(deepEqual('1', 1)).toBe(false);
+  });
+
+  it('handles same reference equality', () => {
+    const obj = { foo: 1 };
+    expect(deepEqual(obj, obj)).toBe(true);
+  });
+
+  it('handles nested arrays', () => {
+    const a = { arr: [[1, 2], [3, 4]] };
+    const b = { arr: [[1, 2], [3, 4]] };
+    expect(deepEqual(a, b)).toBe(true);
+  });
+});

--- a/packages/shared-utils/src/lib/use-mouse-position.test.ts
+++ b/packages/shared-utils/src/lib/use-mouse-position.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { JSDOM } from 'jsdom';
+import { useMousePosition } from './use-mouse-position.js';
+
+describe('useMousePosition', () => {
+  let originalWindow: typeof globalThis.window;
+  let originalDocument: typeof globalThis.document;
+
+  beforeAll(() => {
+    const dom = new JSDOM('<!doctype html><html><body></body></html>');
+    const { window } = dom;
+    originalWindow = globalThis.window;
+    originalDocument = globalThis.document;
+    globalThis.window = window as unknown as typeof globalThis.window;
+    globalThis.document = window.document;
+  });
+
+  afterAll(() => {
+    globalThis.window = originalWindow;
+    globalThis.document = originalDocument;
+  });
+
+  it('updates position on mousemove and cleans up listener', () => {
+    const addSpy = vi.spyOn(window, 'addEventListener');
+    const removeSpy = vi.spyOn(window, 'removeEventListener');
+
+    const { result, unmount } = renderHook(() => useMousePosition());
+
+    expect(addSpy).toHaveBeenCalledWith('mousemove', expect.any(Function));
+    const handler = addSpy.mock.calls[0][1] as (e: MouseEvent) => void;
+
+    act(() => {
+      handler(new window.MouseEvent('mousemove', { clientX: 5, clientY: 10 }));
+    });
+    expect(result.current).toEqual({ x: 5, y: 10 });
+
+    unmount();
+    expect(removeSpy).toHaveBeenCalledWith('mousemove', handler);
+  });
+});

--- a/packages/state/src/action-handlers/add-person.test.ts
+++ b/packages/state/src/action-handlers/add-person.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { addPerson, addPersonHandler } from './add-person.js';
+import {
+  createTestTripState,
+  createTestPerson,
+  getSelectedTripId,
+} from '../__tests__/test-helpers.js';
+
+describe('addPersonHandler', () => {
+  it('adds a new person to the selected trip', () => {
+    const state = createTestTripState({});
+    const tripId = getSelectedTripId(state);
+
+    const action = addPerson({ name: 'Alice', age: 28 });
+    const result = addPersonHandler(state, action);
+
+    const people = result.trips.byId[tripId].people;
+    expect(people).toHaveLength(1);
+    expect(people[0].name).toBe('Alice');
+    expect(people[0].tripId).toBe(tripId);
+  });
+
+  it('does not modify state when no trip is selected', () => {
+    const state = createTestTripState({});
+    state.trips.selectedTripId = null;
+    const action = addPerson({ name: 'Alice', age: 28 });
+    const result = addPersonHandler(state, action);
+    expect(result).toBe(state);
+  });
+
+  it('avoids adding duplicate people', () => {
+    const existing = createTestPerson({ id: 'p1', name: 'Bob' });
+    const state = createTestTripState({ people: [existing] });
+    const tripId = getSelectedTripId(state);
+
+    // Reuse the same id to simulate duplicate
+    const action: Parameters<typeof addPersonHandler>[1] = {
+      type: 'ADD_PERSON',
+      payload: existing,
+    };
+
+    const result = addPersonHandler(state, action);
+    expect(result.trips.byId[tripId].people).toHaveLength(1);
+  });
+});

--- a/packages/state/src/action-handlers/login-modal.test.ts
+++ b/packages/state/src/action-handlers/login-modal.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import {
+  openLoginModalHandler,
+  closeLoginModalHandler,
+} from './login-modal.js';
+import { createTestTripState } from '../__tests__/test-helpers.js';
+
+describe('login modal handlers', () => {
+  it('opens the login modal', () => {
+    const state = createTestTripState({});
+    const result = openLoginModalHandler(state);
+    expect(result.ui.loginModal.isOpen).toBe(true);
+  });
+
+  it('closes the login modal', () => {
+    const state = {
+      ...createTestTripState({}),
+      ui: {
+        ...createTestTripState({}).ui,
+        loginModal: {
+          isOpen: true,
+        },
+      },
+    };
+    const result = closeLoginModalHandler(state);
+    expect(result.ui.loginModal.isOpen).toBe(false);
+  });
+});

--- a/packages/state/src/action-handlers/remove-person.test.ts
+++ b/packages/state/src/action-handlers/remove-person.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { removePersonHandler } from './remove-person.js';
+import {
+  createTestTripState,
+  createTestPerson,
+  getSelectedTripId,
+} from '../__tests__/test-helpers.js';
+
+describe('removePersonHandler', () => {
+  it('removes the specified person', () => {
+    const person = createTestPerson({ id: 'p1' });
+    const state = createTestTripState({ people: [person] });
+    const tripId = getSelectedTripId(state);
+    const action = { type: 'REMOVE_PERSON' as const, payload: { id: 'p1' } };
+    const result = removePersonHandler(state, action);
+    expect(result.trips.byId[tripId].people).toHaveLength(0);
+  });
+
+  it('returns original state when person not found', () => {
+    const state = createTestTripState({});
+    const action = { type: 'REMOVE_PERSON' as const, payload: { id: 'x' } };
+    const result = removePersonHandler(state, action);
+    expect(result).toEqual(state);
+  });
+
+  it('does nothing if no trip selected', () => {
+    const state = createTestTripState({});
+    state.trips.selectedTripId = null;
+    const action = { type: 'REMOVE_PERSON' as const, payload: { id: 'p1' } };
+    const result = removePersonHandler(state, action);
+    expect(result).toBe(state);
+  });
+});

--- a/packages/state/src/action-handlers/rule-pack-modal.test.ts
+++ b/packages/state/src/action-handlers/rule-pack-modal.test.ts
@@ -23,7 +23,7 @@ describe('rule pack modal handlers', () => {
     const state = createTestTripState({});
     const action = {
       type: 'OPEN_RULE_PACK_MODAL' as const,
-      payload: { tab: 'manage', packId: 'p1' },
+      payload: { tab: 'manage' as const, packId: 'p1' },
     };
     const result = openRulePackModalHandler(state, action);
     expect(result.ui.rulePackModal).toEqual({
@@ -36,9 +36,7 @@ describe('rule pack modal handlers', () => {
   it('closes the modal and resets state', () => {
     const state = createTestTripState({});
     state.ui.rulePackModal.isOpen = true;
-    const result = closeRulePackModalHandler(state, {
-      type: 'CLOSE_RULE_PACK_MODAL',
-    });
+    const result = closeRulePackModalHandler(state);
     expect(result.ui.rulePackModal).toEqual({
       isOpen: false,
       activeTab: 'browse',
@@ -51,7 +49,7 @@ describe('rule pack modal handlers', () => {
     state.ui.rulePackModal.isOpen = true;
     const action = {
       type: 'SET_RULE_PACK_MODAL_TAB' as const,
-      payload: { tab: 'details', packId: 'p2' },
+      payload: { tab: 'details' as const, packId: 'p2' },
     };
     const result = setRulePackModalTabHandler(state, action);
     expect(result.ui.rulePackModal).toEqual({

--- a/packages/state/src/action-handlers/rule-pack-modal.test.ts
+++ b/packages/state/src/action-handlers/rule-pack-modal.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import {
+  openRulePackModalHandler,
+  closeRulePackModalHandler,
+  setRulePackModalTabHandler,
+} from './rule-pack-modal.js';
+import { createTestTripState } from '../__tests__/test-helpers.js';
+
+describe('rule pack modal handlers', () => {
+  it('opens the modal with defaults', () => {
+    const state = createTestTripState({});
+    const result = openRulePackModalHandler(state, {
+      type: 'OPEN_RULE_PACK_MODAL',
+    });
+    expect(result.ui.rulePackModal).toEqual({
+      isOpen: true,
+      activeTab: 'browse',
+      selectedPackId: undefined,
+    });
+  });
+
+  it('opens the modal with provided tab', () => {
+    const state = createTestTripState({});
+    const action = {
+      type: 'OPEN_RULE_PACK_MODAL' as const,
+      payload: { tab: 'manage', packId: 'p1' },
+    };
+    const result = openRulePackModalHandler(state, action);
+    expect(result.ui.rulePackModal).toEqual({
+      isOpen: true,
+      activeTab: 'manage',
+      selectedPackId: 'p1',
+    });
+  });
+
+  it('closes the modal and resets state', () => {
+    const state = createTestTripState({});
+    state.ui.rulePackModal.isOpen = true;
+    const result = closeRulePackModalHandler(state, {
+      type: 'CLOSE_RULE_PACK_MODAL',
+    });
+    expect(result.ui.rulePackModal).toEqual({
+      isOpen: false,
+      activeTab: 'browse',
+      selectedPackId: undefined,
+    });
+  });
+
+  it('changes tabs without closing', () => {
+    const state = createTestTripState({});
+    state.ui.rulePackModal.isOpen = true;
+    const action = {
+      type: 'SET_RULE_PACK_MODAL_TAB' as const,
+      payload: { tab: 'details', packId: 'p2' },
+    };
+    const result = setRulePackModalTabHandler(state, action);
+    expect(result.ui.rulePackModal).toEqual({
+      isOpen: true,
+      activeTab: 'details',
+      selectedPackId: 'p2',
+    });
+  });
+});

--- a/packages/state/src/action-handlers/toggle-item-packed.test.ts
+++ b/packages/state/src/action-handlers/toggle-item-packed.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import { toggleItemPackedHandler } from './toggle-item-packed.js';
+import {
+  createTestTripState,
+  getSelectedTripId,
+} from '../__tests__/test-helpers.js';
+import type { PackingListItem } from '@packing-list/model';
+
+describe('toggleItemPackedHandler', () => {
+  const createStateWithItems = (items: PackingListItem[]) => {
+    const state = createTestTripState({});
+    const tripId = getSelectedTripId(state);
+    state.trips.byId[tripId].calculated.packingListItems = items;
+    return { state, tripId };
+  };
+
+  it('toggles packed status for a single item', () => {
+    const item: PackingListItem = {
+      id: 'item1',
+      ruleId: 'r1',
+      name: 'Item 1',
+      itemName: 'Item 1',
+      quantity: 1,
+      isPacked: false,
+      isOverridden: false,
+      isExtra: false,
+      ruleHash: 'hash',
+    };
+    const { state, tripId } = createStateWithItems([item]);
+    const action = {
+      type: 'TOGGLE_ITEM_PACKED' as const,
+      payload: { itemId: 'item1' },
+    };
+
+    const result = toggleItemPackedHandler(state, action);
+    expect(
+      result.trips.byId[tripId].calculated.packingListItems[0].isPacked
+    ).toBe(true);
+
+    const result2 = toggleItemPackedHandler(result, action);
+    expect(
+      result2.trips.byId[tripId].calculated.packingListItems[0].isPacked
+    ).toBe(false);
+  });
+
+  it('does not toggle other items', () => {
+    const items: PackingListItem[] = [
+      {
+        id: 'a',
+        ruleId: 'r',
+        name: 'A',
+        itemName: 'A',
+        quantity: 1,
+        isPacked: false,
+        isOverridden: false,
+        isExtra: false,
+        ruleHash: 'h1',
+      },
+      {
+        id: 'b',
+        ruleId: 'r',
+        name: 'B',
+        itemName: 'B',
+        quantity: 1,
+        isPacked: false,
+        isOverridden: false,
+        isExtra: false,
+        ruleHash: 'h2',
+      },
+    ];
+    const { state, tripId } = createStateWithItems(items);
+    const action = {
+      type: 'TOGGLE_ITEM_PACKED' as const,
+      payload: { itemId: 'a' },
+    };
+
+    const result = toggleItemPackedHandler(state, action);
+    expect(
+      result.trips.byId[tripId].calculated.packingListItems[0].isPacked
+    ).toBe(true);
+    expect(
+      result.trips.byId[tripId].calculated.packingListItems[1].isPacked
+    ).toBe(false);
+  });
+
+  it('returns state unchanged when no trip selected', () => {
+    const state = createTestTripState({});
+    state.trips.selectedTripId = null;
+    const action = {
+      type: 'TOGGLE_ITEM_PACKED' as const,
+      payload: { itemId: 'x' },
+    };
+    const result = toggleItemPackedHandler(state, action);
+    expect(result).toBe(state);
+  });
+});

--- a/packages/state/src/action-handlers/trigger-confetti-burst.test.ts
+++ b/packages/state/src/action-handlers/trigger-confetti-burst.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { triggerConfettiBurstHandler } from './trigger-confetti-burst.js';
+import { createTestTripState } from '../__tests__/test-helpers.js';
+
+describe('triggerConfettiBurstHandler', () => {
+  const originalWindow = globalThis.window;
+
+  afterEach(() => {
+    globalThis.window = originalWindow;
+  });
+
+  it('returns state unchanged when prefers reduced motion', () => {
+    const state = createTestTripState({});
+    const result = triggerConfettiBurstHandler(state, {
+      type: 'TRIGGER_CONFETTI_BURST',
+    });
+    expect(result).toEqual(state);
+  });
+
+  it('updates confetti state when motion allowed', () => {
+    globalThis.window = {
+      matchMedia: vi.fn().mockReturnValue({ matches: false }),
+    } as unknown as Window;
+
+    const state = createTestTripState({});
+    const result = triggerConfettiBurstHandler(state, {
+      type: 'TRIGGER_CONFETTI_BURST',
+      payload: { x: 10, y: 20 },
+    });
+
+    expect(result.ui.confetti.burstId).toBe(state.ui.confetti.burstId + 1);
+    expect(result.ui.confetti.source).toEqual({ x: 10, y: 20, w: 0, h: 0 });
+  });
+});

--- a/packages/state/src/action-handlers/trigger-confetti-burst.test.ts
+++ b/packages/state/src/action-handlers/trigger-confetti-burst.test.ts
@@ -20,7 +20,7 @@ describe('triggerConfettiBurstHandler', () => {
   it('updates confetti state when motion allowed', () => {
     globalThis.window = {
       matchMedia: vi.fn().mockReturnValue({ matches: false }),
-    } as unknown as Window;
+    } as unknown as Window & typeof globalThis;
 
     const state = createTestTripState({});
     const result = triggerConfettiBurstHandler(state, {

--- a/packages/state/src/action-handlers/update-item-rule.test.ts
+++ b/packages/state/src/action-handlers/update-item-rule.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { updateItemRuleHandler } from './update-item-rule.js';
+import {
+  createTestTripState,
+  getSelectedTripId,
+} from '../__tests__/test-helpers.js';
+import type { DefaultItemRule } from '@packing-list/model';
+
+describe('updateItemRuleHandler', () => {
+  const createRule = (id: string, name = 'Rule'): DefaultItemRule => ({
+    id,
+    originalRuleId: id,
+    name,
+    calculation: { baseQuantity: 1, perPerson: false, perDay: false },
+    conditions: [],
+    notes: '',
+    categoryId: '',
+    subcategoryId: '',
+    packIds: [],
+  });
+
+  it('updates an existing rule', () => {
+    const rule = createRule('r1', 'Old');
+    const state = createTestTripState({});
+    const tripId = getSelectedTripId(state);
+    state.trips.byId[tripId].trip.defaultItemRules = [rule];
+
+    const updated = { ...rule, name: 'Updated' };
+    const action = { type: 'UPDATE_ITEM_RULE' as const, payload: updated };
+    const result = updateItemRuleHandler(state, action);
+
+    expect(result.trips.byId[tripId].trip.defaultItemRules[0].name).toBe(
+      'Updated'
+    );
+  });
+
+  it('does nothing when no trip is selected', () => {
+    const state = createTestTripState({});
+    state.trips.selectedTripId = null;
+    const rule = createRule('r1');
+    const action = { type: 'UPDATE_ITEM_RULE' as const, payload: rule };
+    const result = updateItemRuleHandler(state, action);
+    expect(result).toBe(state);
+  });
+});

--- a/packages/state/src/action-handlers/update-person.test.ts
+++ b/packages/state/src/action-handlers/update-person.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { updatePersonHandler } from './update-person.js';
+import {
+  createTestTripState,
+  createTestPerson,
+  getSelectedTripId,
+} from '../__tests__/test-helpers.js';
+import type { Person } from '@packing-list/model';
+
+describe('updatePersonHandler', () => {
+  it('updates an existing person', () => {
+    const person = createTestPerson({ id: 'p1', name: 'Old' });
+    const state = createTestTripState({ people: [person] });
+    const tripId = getSelectedTripId(state);
+
+    const updated: Person = { ...person, name: 'New Name', age: 40 };
+    const action = { type: 'UPDATE_PERSON' as const, payload: updated };
+    const result = updatePersonHandler(state, action);
+
+    const updatedPerson = result.trips.byId[tripId].people[0];
+    expect(updatedPerson.name).toBe('New Name');
+    expect(updatedPerson.age).toBe(40);
+  });
+
+  it('does nothing when no trip is selected', () => {
+    const state = createTestTripState({});
+    state.trips.selectedTripId = null;
+    const person = createTestPerson({ id: 'p1' });
+    const action = { type: 'UPDATE_PERSON' as const, payload: person };
+    const result = updatePersonHandler(state, action);
+    expect(result).toBe(state);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,9 @@ importers:
       '@types/jest':
         specifier: ^29.5.14
         version: 29.5.14
+      '@types/jsdom':
+        specifier: ^21.1.7
+        version: 21.1.7
       '@types/node':
         specifier: 18.16.9
         version: 18.16.9
@@ -1944,6 +1947,9 @@ packages:
   '@types/jest@29.5.14':
     resolution: {integrity: sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==}
 
+  '@types/jsdom@21.1.7':
+    resolution: {integrity: sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
@@ -1983,6 +1989,9 @@ packages:
 
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
+
+  '@types/tough-cookie@4.0.5':
+    resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
 
   '@types/use-sync-external-store@0.0.6':
     resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
@@ -7989,6 +7998,12 @@ snapshots:
       expect: 29.7.0
       pretty-format: 29.7.0
 
+  '@types/jsdom@21.1.7':
+    dependencies:
+      '@types/node': 18.16.9
+      '@types/tough-cookie': 4.0.5
+      parse5: 7.3.0
+
   '@types/json-schema@7.0.15': {}
 
   '@types/keyv@3.1.4':
@@ -8025,6 +8040,8 @@ snapshots:
       '@types/node': 18.16.9
 
   '@types/stack-utils@2.0.3': {}
+
+  '@types/tough-cookie@4.0.5': {}
 
   '@types/use-sync-external-store@0.0.6': {}
 


### PR DESCRIPTION
## Summary
- add tests for Dialog modal interactions
- cover Banner provider behavior
- test SyncStatusIndicator badges
- verify conflict list and banner functionality
- ensure OfflineBanner and diff components render correctly

## Testing
- `pnpm nx run-many -t lint,test,build`

------
https://chatgpt.com/codex/tasks/task_e_686808761b40832ca5dad0bb09c678a2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for Banner, ConflictBanner, ConflictDiffView, ConflictList, Dialog (Modal and ConfirmDialog), NestedObjectDiff, OfflineBanner, and SyncStatusBadge components.
  * Added tests for utility functions and hooks including calculateRuleHash, calculateRule, deepEqual, useMousePosition, and various state action handlers.
  * Tests validate rendering, user interactions, callback invocations, state transitions, and logic correctness across multiple scenarios to ensure reliable behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->