### PR TITLE
test: add action handler unit tests

### DIFF
--- a/packages/state/src/action-handlers/add-person.test.ts
+++ b/packages/state/src/action-handlers/add-person.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { addPerson, addPersonHandler } from './add-person.js';
+import {
+  createTestTripState,
+  createTestPerson,
+  getSelectedTripId,
+} from '../__tests__/test-helpers.js';
+
+describe('addPersonHandler', () => {
+  it('adds a new person to the selected trip', () => {
+    const state = createTestTripState({});
+    const tripId = getSelectedTripId(state);
+
+    const action = addPerson({ name: 'Alice', age: 28 });
+    const result = addPersonHandler(state, action);
+
+    const people = result.trips.byId[tripId].people;
+    expect(people).toHaveLength(1);
+    expect(people[0].name).toBe('Alice');
+    expect(people[0].tripId).toBe(tripId);
+  });
+
+  it('does not modify state when no trip is selected', () => {
+    const state = createTestTripState({});
+    state.trips.selectedTripId = null;
+    const action = addPerson({ name: 'Alice', age: 28 });
+    const result = addPersonHandler(state, action);
+    expect(result).toBe(state);
+  });
+
+  it('avoids adding duplicate people', () => {
+    const existing = createTestPerson({ id: 'p1', name: 'Bob' });
+    const state = createTestTripState({ people: [existing] });
+    const tripId = getSelectedTripId(state);
+
+    // Reuse the same id to simulate duplicate
+    const action: Parameters<typeof addPersonHandler>[1] = {
+      type: 'ADD_PERSON',
+      payload: existing,
+    };
+
+    const result = addPersonHandler(state, action);
+    expect(result.trips.byId[tripId].people).toHaveLength(1);
+  });
+});

--- a/packages/state/src/action-handlers/login-modal.test.ts
+++ b/packages/state/src/action-handlers/login-modal.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import {
+  openLoginModalHandler,
+  closeLoginModalHandler,
+} from './login-modal.js';
+import { createTestTripState } from '../__tests__/test-helpers.js';
+
+describe('login modal handlers', () => {
+  it('opens the login modal', () => {
+    const state = createTestTripState({});
+    const result = openLoginModalHandler(state);
+    expect(result.ui.loginModal.isOpen).toBe(true);
+  });
+
+  it('closes the login modal', () => {
+    const state = createTestTripState({});
+    state.ui.loginModal.isOpen = true;
+    const result = closeLoginModalHandler(state);
+    expect(result.ui.loginModal.isOpen).toBe(false);
+  });
+});

--- a/packages/state/src/action-handlers/remove-person.test.ts
+++ b/packages/state/src/action-handlers/remove-person.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { removePersonHandler } from './remove-person.js';
+import {
+  createTestTripState,
+  createTestPerson,
+  getSelectedTripId,
+} from '../__tests__/test-helpers.js';
+
+describe('removePersonHandler', () => {
+  it('removes the specified person', () => {
+    const person = createTestPerson({ id: 'p1' });
+    const state = createTestTripState({ people: [person] });
+    const tripId = getSelectedTripId(state);
+    const action = { type: 'REMOVE_PERSON' as const, payload: { id: 'p1' } };
+    const result = removePersonHandler(state, action);
+    expect(result.trips.byId[tripId].people).toHaveLength(0);
+  });
+
+  it('returns original state when person not found', () => {
+    const state = createTestTripState({});
+    const action = { type: 'REMOVE_PERSON' as const, payload: { id: 'x' } };
+    const result = removePersonHandler(state, action);
+    expect(result).toEqual(state);
+  });
+
+  it('does nothing if no trip selected', () => {
+    const state = createTestTripState({});
+    state.trips.selectedTripId = null;
+    const action = { type: 'REMOVE_PERSON' as const, payload: { id: 'p1' } };
+    const result = removePersonHandler(state, action);
+    expect(result).toBe(state);
+  });
+});

--- a/packages/state/src/action-handlers/rule-pack-modal.test.ts
+++ b/packages/state/src/action-handlers/rule-pack-modal.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import {
+  openRulePackModalHandler,
+  closeRulePackModalHandler,
+  setRulePackModalTabHandler,
+} from './rule-pack-modal.js';
+import { createTestTripState } from '../__tests__/test-helpers.js';
+
+describe('rule pack modal handlers', () => {
+  it('opens the modal with defaults', () => {
+    const state = createTestTripState({});
+    const result = openRulePackModalHandler(state, {
+      type: 'OPEN_RULE_PACK_MODAL',
+    });
+    expect(result.ui.rulePackModal).toEqual({
+      isOpen: true,
+      activeTab: 'browse',
+      selectedPackId: undefined,
+    });
+  });
+
+  it('opens the modal with provided tab', () => {
+    const state = createTestTripState({});
+    const action = {
+      type: 'OPEN_RULE_PACK_MODAL' as const,
+      payload: { tab: 'manage', packId: 'p1' },
+    };
+    const result = openRulePackModalHandler(state, action);
+    expect(result.ui.rulePackModal).toEqual({
+      isOpen: true,
+      activeTab: 'manage',
+      selectedPackId: 'p1',
+    });
+  });
+
+  it('closes the modal and resets state', () => {
+    const state = createTestTripState({});
+    state.ui.rulePackModal.isOpen = true;
+    const result = closeRulePackModalHandler(state, {
+      type: 'CLOSE_RULE_PACK_MODAL',
+    });
+    expect(result.ui.rulePackModal).toEqual({
+      isOpen: false,
+      activeTab: 'browse',
+      selectedPackId: undefined,
+    });
+  });
+
+  it('changes tabs without closing', () => {
+    const state = createTestTripState({});
+    state.ui.rulePackModal.isOpen = true;
+    const action = {
+      type: 'SET_RULE_PACK_MODAL_TAB' as const,
+      payload: { tab: 'details', packId: 'p2' },
+    };
+    const result = setRulePackModalTabHandler(state, action);
+    expect(result.ui.rulePackModal).toEqual({
+      isOpen: true,
+      activeTab: 'details',
+      selectedPackId: 'p2',
+    });
+  });
+});

--- a/packages/state/src/action-handlers/toggle-item-packed.test.ts
+++ b/packages/state/src/action-handlers/toggle-item-packed.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import { toggleItemPackedHandler } from './toggle-item-packed.js';
+import {
+  createTestTripState,
+  getSelectedTripId,
+} from '../__tests__/test-helpers.js';
+import type { PackingListItem } from '@packing-list/model';
+
+describe('toggleItemPackedHandler', () => {
+  const createStateWithItems = (items: PackingListItem[]) => {
+    const state = createTestTripState({});
+    const tripId = getSelectedTripId(state);
+    state.trips.byId[tripId].calculated.packingListItems = items;
+    return { state, tripId };
+  };
+
+  it('toggles packed status for a single item', () => {
+    const item: PackingListItem = {
+      id: 'item1',
+      ruleId: 'r1',
+      name: 'Item 1',
+      itemName: 'Item 1',
+      quantity: 1,
+      isPacked: false,
+      isOverridden: false,
+      isExtra: false,
+      ruleHash: 'hash',
+    };
+    const { state, tripId } = createStateWithItems([item]);
+    const action = {
+      type: 'TOGGLE_ITEM_PACKED' as const,
+      payload: { itemId: 'item1' },
+    };
+
+    const result = toggleItemPackedHandler(state, action);
+    expect(
+      result.trips.byId[tripId].calculated.packingListItems[0].isPacked
+    ).toBe(true);
+
+    const result2 = toggleItemPackedHandler(result, action);
+    expect(
+      result2.trips.byId[tripId].calculated.packingListItems[0].isPacked
+    ).toBe(false);
+  });
+
+  it('does not toggle other items', () => {
+    const items: PackingListItem[] = [
+      {
+        id: 'a',
+        ruleId: 'r',
+        name: 'A',
+        itemName: 'A',
+        quantity: 1,
+        isPacked: false,
+        isOverridden: false,
+        isExtra: false,
+        ruleHash: 'h1',
+      },
+      {
+        id: 'b',
+        ruleId: 'r',
+        name: 'B',
+        itemName: 'B',
+        quantity: 1,
+        isPacked: false,
+        isOverridden: false,
+        isExtra: false,
+        ruleHash: 'h2',
+      },
+    ];
+    const { state, tripId } = createStateWithItems(items);
+    const action = {
+      type: 'TOGGLE_ITEM_PACKED' as const,
+      payload: { itemId: 'a' },
+    };
+
+    const result = toggleItemPackedHandler(state, action);
+    expect(
+      result.trips.byId[tripId].calculated.packingListItems[0].isPacked
+    ).toBe(true);
+    expect(
+      result.trips.byId[tripId].calculated.packingListItems[1].isPacked
+    ).toBe(false);
+  });
+
+  it('returns state unchanged when no trip selected', () => {
+    const state = createTestTripState({});
+    state.trips.selectedTripId = null;
+    const action = {
+      type: 'TOGGLE_ITEM_PACKED' as const,
+      payload: { itemId: 'x' },
+    };
+    const result = toggleItemPackedHandler(state, action);
+    expect(result).toBe(state);
+  });
+});

--- a/packages/state/src/action-handlers/trigger-confetti-burst.test.ts
+++ b/packages/state/src/action-handlers/trigger-confetti-burst.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { triggerConfettiBurstHandler } from './trigger-confetti-burst.js';
+import { createTestTripState } from '../__tests__/test-helpers.js';
+
+describe('triggerConfettiBurstHandler', () => {
+  const originalWindow = globalThis.window;
+
+  afterEach(() => {
+    globalThis.window = originalWindow;
+  });
+
+  it('returns state unchanged when prefers reduced motion', () => {
+    const state = createTestTripState({});
+    const result = triggerConfettiBurstHandler(state, {
+      type: 'TRIGGER_CONFETTI_BURST',
+    });
+    expect(result).toEqual(state);
+  });
+
+  it('updates confetti state when motion allowed', () => {
+    globalThis.window = {
+      matchMedia: vi.fn().mockReturnValue({ matches: false }),
+    } as unknown as Window;
+
+    const state = createTestTripState({});
+    const result = triggerConfettiBurstHandler(state, {
+      type: 'TRIGGER_CONFETTI_BURST',
+      payload: { x: 10, y: 20 },
+    });
+
+    expect(result.ui.confetti.burstId).toBe(state.ui.confetti.burstId + 1);
+    expect(result.ui.confetti.source).toEqual({ x: 10, y: 20, w: 0, h: 0 });
+  });
+});

--- a/packages/state/src/action-handlers/update-item-rule.test.ts
+++ b/packages/state/src/action-handlers/update-item-rule.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { updateItemRuleHandler } from './update-item-rule.js';
+import {
+  createTestTripState,
+  getSelectedTripId,
+} from '../__tests__/test-helpers.js';
+import type { DefaultItemRule } from '@packing-list/model';
+
+describe('updateItemRuleHandler', () => {
+  const createRule = (id: string, name = 'Rule'): DefaultItemRule => ({
+    id,
+    originalRuleId: id,
+    name,
+    calculation: { baseQuantity: 1, perPerson: false, perDay: false },
+    conditions: [],
+    notes: '',
+    categoryId: '',
+    subcategoryId: '',
+    packIds: [],
+  });
+
+  it('updates an existing rule', () => {
+    const rule = createRule('r1', 'Old');
+    const state = createTestTripState({});
+    const tripId = getSelectedTripId(state);
+    state.trips.byId[tripId].trip.defaultItemRules = [rule];
+
+    const updated = { ...rule, name: 'Updated' };
+    const action = { type: 'UPDATE_ITEM_RULE' as const, payload: updated };
+    const result = updateItemRuleHandler(state, action);
+
+    expect(result.trips.byId[tripId].trip.defaultItemRules[0].name).toBe(
+      'Updated'
+    );
+  });
+
+  it('does nothing when no trip is selected', () => {
+    const state = createTestTripState({});
+    state.trips.selectedTripId = null;
+    const rule = createRule('r1');
+    const action = { type: 'UPDATE_ITEM_RULE' as const, payload: rule };
+    const result = updateItemRuleHandler(state, action);
+    expect(result).toBe(state);
+  });
+});

--- a/packages/state/src/action-handlers/update-person.test.ts
+++ b/packages/state/src/action-handlers/update-person.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { updatePersonHandler } from './update-person.js';
+import {
+  createTestTripState,
+  createTestPerson,
+  getSelectedTripId,
+} from '../__tests__/test-helpers.js';
+import type { Person } from '@packing-list/model';
+
+describe('updatePersonHandler', () => {
+  it('updates an existing person', () => {
+    const person = createTestPerson({ id: 'p1', name: 'Old' });
+    const state = createTestTripState({ people: [person] });
+    const tripId = getSelectedTripId(state);
+
+    const updated: Person = { ...person, name: 'New Name', age: 40 };
+    const action = { type: 'UPDATE_PERSON' as const, payload: updated };
+    const result = updatePersonHandler(state, action);
+
+    const updatedPerson = result.trips.byId[tripId].people[0];
+    expect(updatedPerson.name).toBe('New Name');
+    expect(updatedPerson.age).toBe(40);
+  });
+
+  it('does nothing when no trip is selected', () => {
+    const state = createTestTripState({});
+    state.trips.selectedTripId = null;
+    const person = createTestPerson({ id: 'p1' });
+    const action = { type: 'UPDATE_PERSON' as const, payload: person };
+    const result = updatePersonHandler(state, action);
+    expect(result).toBe(state);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for core action handlers
- cover person, rule pack modal, login modal and confetti actions

## Testing
- `pnpm nx run-many -t lint,test,build`

------
https://chatgpt.com/codex/tasks/task_e_68680881738c832c90d3d0b1aa8c1162