### PR TITLE
test: add shared-utils unit tests

### DIFF
--- a/packages/shared-utils/src/lib/calculate-rule-hash.test.ts
+++ b/packages/shared-utils/src/lib/calculate-rule-hash.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { calculateRuleHash } from './calculate-rule-hash.js';
+import type { DefaultItemRule } from '@packing-list/model';
+
+describe('calculateRuleHash', () => {
+  const baseRule: DefaultItemRule = {
+    id: '1',
+    originalRuleId: '1',
+    name: 'Test',
+    calculation: { baseQuantity: 1 },
+    conditions: [{ property: 'test', operator: 'equals', value: 'value' }],
+  };
+
+  it('produces stable hashes for identical rules', () => {
+    const hash1 = calculateRuleHash(baseRule);
+    const hash2 = calculateRuleHash({ ...baseRule });
+    expect(hash1).toBe(hash2);
+  });
+
+  it('produces different hashes for different rules', () => {
+    const otherRule: DefaultItemRule = {
+      ...baseRule,
+      name: 'Other',
+    };
+    const hash1 = calculateRuleHash(baseRule);
+    const hash2 = calculateRuleHash(otherRule);
+    expect(hash1).not.toBe(hash2);
+  });
+});

--- a/packages/shared-utils/src/lib/calculate-rule.test.ts
+++ b/packages/shared-utils/src/lib/calculate-rule.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'vitest';
+import {
+  calculateItemQuantity,
+  calculateNumDaysMeetingCondition,
+  calculateNumPeopleMeetingCondition,
+  calculateRuleTotal,
+  compare,
+} from './calculate-rule.js';
+import type { DefaultItemRule, Person, Day } from '@packing-list/model';
+
+describe('calculate-rule utilities', () => {
+  it('compare handles numeric and array operators', () => {
+    expect(compare(3, '>', 2)).toBe(true);
+    expect(compare(3, '<', 2)).toBe(false);
+    expect(compare(['a', 'b'], 'in', 'a')).toBe(true);
+    expect(compare('a', 'in', ['a', 'b'])).toBe(true);
+  });
+
+  it('calculates item quantity with per person and per day flags', () => {
+    const qty = calculateItemQuantity(
+      1,
+      true,
+      true,
+      { every: 2, roundUp: true },
+      3,
+      5
+    );
+    // perPerson multiplies by people (3) and perDay multiplies by daysPattern result ceil(5/2)=3
+    expect(qty).toBe(9);
+  });
+
+  it('counts people and days meeting conditions', () => {
+    const people: Person[] = [
+      {
+        id: '1',
+        tripId: 't',
+        name: 'Alice',
+        createdAt: '',
+        updatedAt: '',
+        version: 1,
+        isDeleted: false,
+        age: 20,
+      },
+      {
+        id: '2',
+        tripId: 't',
+        name: 'Bob',
+        createdAt: '',
+        updatedAt: '',
+        version: 1,
+        isDeleted: false,
+        age: 30,
+      },
+    ];
+    const days: Day[] = [
+      {
+        location: 'a',
+        expectedClimate: 'hot',
+        items: [],
+        travel: false,
+        date: 1,
+      },
+      {
+        location: 'b',
+        expectedClimate: 'cold',
+        items: [],
+        travel: false,
+        date: 2,
+      },
+    ];
+    const peopleCount = calculateNumPeopleMeetingCondition(people, [
+      { type: 'person', field: 'age', operator: '>', value: 25 },
+    ]);
+    const daysCount = calculateNumDaysMeetingCondition(days, [
+      { type: 'day', field: 'expectedClimate', operator: '==', value: 'hot' },
+    ]);
+    expect(peopleCount).toBe(1);
+    expect(daysCount).toBe(1);
+  });
+
+  it('calculates rule total with extra items and conditions', () => {
+    const rule: DefaultItemRule = {
+      id: 'r1',
+      originalRuleId: 'r1',
+      name: 'Socks',
+      calculation: {
+        baseQuantity: 1,
+        perPerson: true,
+        perDay: true,
+        daysPattern: { every: 1, roundUp: true },
+        extraItems: { quantity: 2, perPerson: false, perDay: false },
+      },
+      conditions: [
+        { type: 'person', field: 'age', operator: '>=', value: 18 },
+        {
+          type: 'day',
+          field: 'expectedClimate',
+          operator: '==',
+          value: 'cold',
+        },
+      ],
+    };
+    const people: Person[] = [
+      {
+        id: '1',
+        tripId: 't',
+        name: 'Alice',
+        age: 20,
+        createdAt: '',
+        updatedAt: '',
+        version: 1,
+        isDeleted: false,
+      },
+      {
+        id: '2',
+        tripId: 't',
+        name: 'Bob',
+        age: 16,
+        createdAt: '',
+        updatedAt: '',
+        version: 1,
+        isDeleted: false,
+      },
+    ];
+    const days: Day[] = [
+      {
+        location: 'a',
+        expectedClimate: 'cold',
+        items: [],
+        travel: false,
+        date: 1,
+      },
+      {
+        location: 'b',
+        expectedClimate: 'warm',
+        items: [],
+        travel: false,
+        date: 2,
+      },
+    ];
+
+    const total = calculateRuleTotal(rule, people, days);
+    // Only Alice and first day meet conditions => people=1 days=1
+    // baseQuantity 1 * 1 * 1 =1 ; extra items 2
+    expect(total).toBe(3);
+  });
+});

--- a/packages/shared-utils/src/lib/deep-equal.test.ts
+++ b/packages/shared-utils/src/lib/deep-equal.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { deepEqual } from './deep-equal.js';
+
+describe('deepEqual', () => {
+  it('handles objects with keys in different order', () => {
+    const a = { foo: 1, bar: { baz: [1, 2, 3] } };
+    const b = { bar: { baz: [1, 2, 3] }, foo: 1 };
+    expect(deepEqual(a, b)).toBe(true);
+  });
+
+  it('detects unequal primitive values', () => {
+    expect(deepEqual(1, 2)).toBe(false);
+  });
+
+  it('detects unequal nested objects', () => {
+    const a = { foo: { bar: 1 } };
+    const b = { foo: { bar: 2 } };
+    expect(deepEqual(a, b)).toBe(false);
+  });
+
+  it('compares arrays by value', () => {
+    expect(deepEqual([1, 2, 3], [1, 2, 3])).toBe(true);
+    expect(deepEqual([1, 2], [2, 1])).toBe(false);
+  });
+
+  it('handles null and undefined values', () => {
+    expect(deepEqual(null, null)).toBe(true);
+    expect(deepEqual(undefined, undefined)).toBe(true);
+    expect(deepEqual(null, undefined)).toBe(false);
+    expect(deepEqual(null, {})).toBe(false);
+  });
+
+  it('handles equal primitive values', () => {
+    expect(deepEqual(1, 1)).toBe(true);
+    expect(deepEqual('hello', 'hello')).toBe(true);
+    expect(deepEqual(true, true)).toBe(true);
+  });
+
+  it('handles empty collections', () => {
+    expect(deepEqual({}, {})).toBe(true);
+    expect(deepEqual([], [])).toBe(true);
+    expect(deepEqual({}, [])).toBe(false);
+  });
+
+  it('handles mixed type comparisons', () => {
+    expect(deepEqual({}, [])).toBe(false);
+    expect(deepEqual([], {})).toBe(false);
+    expect(deepEqual('1', 1)).toBe(false);
+  });
+
+  it('handles same reference equality', () => {
+    const obj = { foo: 1 };
+    expect(deepEqual(obj, obj)).toBe(true);
+  });
+
+  it('handles nested arrays', () => {
+    const a = { arr: [[1, 2], [3, 4]] };
+    const b = { arr: [[1, 2], [3, 4]] };
+    expect(deepEqual(a, b)).toBe(true);
+  });
+});

--- a/packages/shared-utils/src/lib/use-mouse-position.test.ts
+++ b/packages/shared-utils/src/lib/use-mouse-position.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { JSDOM } from 'jsdom';
+import { useMousePosition } from './use-mouse-position.js';
+
+describe('useMousePosition', () => {
+  let originalWindow: typeof globalThis.window;
+  let originalDocument: typeof globalThis.document;
+
+  beforeAll(() => {
+    const dom = new JSDOM('<!doctype html><html><body></body></html>');
+    const { window } = dom;
+    originalWindow = globalThis.window;
+    originalDocument = globalThis.document;
+    globalThis.window = window as unknown as typeof globalThis.window;
+    globalThis.document = window.document;
+  });
+
+  afterAll(() => {
+    globalThis.window = originalWindow;
+    globalThis.document = originalDocument;
+  });
+
+  // ... existing tests ...
+});
+
+  it('updates position on mousemove and cleans up listener', () => {
+    const addSpy = vi.spyOn(window, 'addEventListener');
+    const removeSpy = vi.spyOn(window, 'removeEventListener');
+
+    const { result, unmount } = renderHook(() => useMousePosition());
+
+    expect(addSpy).toHaveBeenCalledWith('mousemove', expect.any(Function));
+    const handler = addSpy.mock.calls[0][1] as (e: MouseEvent) => void;
+
+    act(() => {
+      handler(new window.MouseEvent('mousemove', { clientX: 5, clientY: 10 }));
+    });
+    expect(result.current).toEqual({ x: 5, y: 10 });
+
+    unmount();
+    expect(removeSpy).toHaveBeenCalledWith('mousemove', handler);
+  });
+});

--- a/packages/shared-utils/src/lib/use-mouse-position.test.ts
+++ b/packages/shared-utils/src/lib/use-mouse-position.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { JSDOM } from 'jsdom';
 import { useMousePosition } from './use-mouse-position.js';
@@ -20,9 +20,6 @@ describe('useMousePosition', () => {
     globalThis.window = originalWindow;
     globalThis.document = originalDocument;
   });
-
-  // ... existing tests ...
-});
 
   it('updates position on mousemove and cleans up listener', () => {
     const addSpy = vi.spyOn(window, 'addEventListener');


### PR DESCRIPTION
## Summary
- add unit tests for deepEqual
- add unit tests for calculate-rule utilities
- verify rule hash stability
- test useMousePosition hook cleanup

## Testing
- `pnpm nx run-many -t lint,test,build`

------
https://chatgpt.com/codex/tasks/task_e_68680888a0d0832caa39e75a24b38dff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added new unit tests for rule hashing, rule-based calculation utilities, deep equality checks, and mouse position tracking.
  * Verified correct behavior for comparison, quantity calculation, and event handling in the respective modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->